### PR TITLE
Add Hanzilla Jobs to job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Search for jobs directly in Google and setup *email* alerts on the [Google job p
 - https://getsilverlining.com/job-board
 - https://github.com/poteto/hiring-without-whiteboards
 - https://hiretechladies.com
+- https://jobs.hanzilla.co/ - Canada-focused student and recent-grad jobs across internships, co-ops, junior, and entry-level roles
 - https://jobs.foodtechconnect.com
 - https://jobs.github.com
 - https://jobs.workable.com

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Search for jobs directly in Google and setup *email* alerts on the [Google job p
 - https://getsilverlining.com/job-board
 - https://github.com/poteto/hiring-without-whiteboards
 - https://hiretechladies.com
-- https://jobs.hanzilla.co/ - Canada-focused student and recent-grad jobs across internships, co-ops, junior, and entry-level roles
+- https://jobs.hanzilla.co
 - https://jobs.foodtechconnect.com
 - https://jobs.github.com
 - https://jobs.workable.com


### PR DESCRIPTION
## Summary
- Adds Hanzilla Jobs to the job boards list as a Canada-focused student/recent-grad resource.
- Hanzilla Jobs is free and updated daily with internships, co-ops, junior, and entry-level roles across multiple fields.

## Link
https://jobs.hanzilla.co/
