### PR TITLE
Add Hanzilla Jobs to job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Search for jobs directly in Google and setup *email* alerts on the [Google job p
 - https://diversifytech.co/job-board
 - https://getsilverlining.com/job-board
 - https://github.com/poteto/hiring-without-whiteboards
+- [Hanzilla Jobs](https://jobs.hanzilla.co/internships/) - Free daily-updated Canadian student/recent-grad job board for internships, co-ops, new-grad, junior, and entry-level roles across tech, finance, engineering, business, sciences, and more.
 - https://hiretechladies.com
 - https://jobs.foodtechconnect.com
 - https://jobs.github.com


### PR DESCRIPTION
## Summary
- Add Hanzilla Jobs to the Job Boards section as a Canada-specific student/recent-grad job board.
- Use the internships deep link because the list is meant to help people quickly find practical job-search sources.

## Why this may fit
Hanzilla Jobs is a free daily-updated board for Canadian university students and recent grads looking for internships, co-ops, new-grad, junior, and entry-level roles across tech plus adjacent fields like finance, engineering, business, and sciences.

Disclosure: I’m the builder/maintainer of Hanzilla Jobs. If this is too niche for the list, no worries — thanks for maintaining the resource.

## Verification
- Verified `https://jobs.hanzilla.co/internships/` returns 200, has a self-canonical, and is not `noindex`.
- Ran `git diff --check`.
